### PR TITLE
Update write exception handling

### DIFF
--- a/src/Exceptions/InvalidSourceUrlException.php
+++ b/src/Exceptions/InvalidSourceUrlException.php
@@ -6,7 +6,6 @@ namespace NSWDPC\Embed\Exceptions;
  * This exception is thrown when the embed source url is invalid or
  * missing required parts
  */
-class InvalidSourceUrlException extends \Exception {
-
-
+class InvalidSourceUrlException extends \Exception
+{
 }

--- a/src/Exceptions/InvalidSourceUrlException.php
+++ b/src/Exceptions/InvalidSourceUrlException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace NSWDPC\Embed\Exceptions;
+
+/**
+ * This exception is thrown when the embed source url is invalid or
+ * missing required parts
+ */
+class InvalidSourceUrlException extends \Exception {
+
+
+}

--- a/src/Extensions/Embeddable.php
+++ b/src/Extensions/Embeddable.php
@@ -181,7 +181,7 @@ class Embeddable extends DataExtension
             throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL', 'Source URL is empty'));
         }
 
-        $parts = parse_url((string) $sourceURL);
+        $parts = parse_url($sourceURL);
         if (!isset($parts['scheme'])) {
             throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL_SCHEME', 'Source URL has no scheme'));
         }
@@ -237,7 +237,7 @@ class Embeddable extends DataExtension
 
             return true;
 
-        } catch (InvalidSourceUrlException $invalidSourceUrlException) {
+        } catch (InvalidSourceUrlException) {
             return false;
         } catch (\Throwable $throwable) {
             Logger::log("Error writing embed object: " . $throwable->getMessage(), "NOTICE");

--- a/src/Extensions/Embeddable.php
+++ b/src/Extensions/Embeddable.php
@@ -5,6 +5,7 @@ namespace NSWDPC\Embed\Extensions;
 use Embed\Embed;
 use Embed\Extractor;
 use Embed\OEmbed;
+use NSWDPC\Embed\Exceptions\InvalidSourceUrlException;
 use NSWDPC\Embed\Services\Logger;
 use SilverStripe\Assets\Image;
 use SilverStripe\Assets\Folder;
@@ -164,21 +165,22 @@ class Embeddable extends DataExtension
 
     /**
      * Get the Extractor for the source URL
+     * @throws InvalidSourceUrlException
      */
     public function getExtractor(): Extractor
     {
-        $sourceURL = $this->getOwner()->EmbedSourceURL ?? '';
+        $sourceURL = trim($this->getOwner()->EmbedSourceURL ?? '');
         if($sourceURL === '') {
-            throw new \RuntimeException(_t(self::class . '.EMPTY_SOURCE_URL', 'Source URL is empty'));
+            throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL', 'Source URL is empty'));
         }
 
         $parts = parse_url($sourceURL);
         if(!isset($parts['scheme'])) {
-            throw new \RuntimeException(_t(self::class . '.EMPTY_SOURCE_URL_SCHEME', 'Source URL has no scheme'));
+            throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL_SCHEME', 'Source URL has no scheme'));
         }
 
         if(!isset($parts['host'])) {
-            throw new \RuntimeException(_t(self::class . '.EMPTY_SOURCE_URL_HOST', 'Source URL has no host'));
+            throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL_HOST', 'Source URL has no host'));
         }
 
         $embed = new Embed();
@@ -195,6 +197,7 @@ class Embeddable extends DataExtension
 
     /**
      * Get the embed data using a source URL and write relevant data to the owner
+     * @throws \SilverStripe\ORM\ValidationException
      */
     protected function writeFromEmbed(bool $force = false): bool
     {
@@ -227,6 +230,9 @@ class Embeddable extends DataExtension
 
             return true;
 
+        } catch (InvalidSourceUrlException $invalidSourceUrlException) {
+            Logger::log("Error with embed source url: {$invalidSourceUrlException->getMessage()}", "INFO");
+            return false;
         } catch (\Throwable $throwable) {
             Logger::log("Error writing embed object: " . $throwable->getMessage(), "NOTICE");
             throw \SilverStripe\ORM\ValidationException::create(_t(

--- a/src/Extensions/Embeddable.php
+++ b/src/Extensions/Embeddable.php
@@ -210,7 +210,7 @@ class Embeddable extends DataExtension
     {
         try {
             $extractor = $this->getExtractor();
-            if(is_null($extractor)) {
+            if (is_null($extractor)) {
                 // no extractor.. URL is empty
                 return false;
             }

--- a/src/Extensions/Embeddable.php
+++ b/src/Extensions/Embeddable.php
@@ -231,7 +231,6 @@ class Embeddable extends DataExtension
             return true;
 
         } catch (InvalidSourceUrlException $invalidSourceUrlException) {
-            Logger::log("Error with embed source url: {$invalidSourceUrlException->getMessage()}", "INFO");
             return false;
         } catch (\Throwable $throwable) {
             Logger::log("Error writing embed object: " . $throwable->getMessage(), "NOTICE");

--- a/src/Extensions/Embeddable.php
+++ b/src/Extensions/Embeddable.php
@@ -171,14 +171,14 @@ class Embeddable extends DataExtension
     }
 
     /**
-     * Get the Extractor for the source URL
+     * Get the Extractor for the source URL, or return null if the source URL is empty
      * @throws InvalidSourceUrlException
      */
-    public function getExtractor(): Extractor
+    public function getExtractor(): ?Extractor
     {
         $sourceURL = trim($this->getOwner()->EmbedSourceURL ?? '');
         if ($sourceURL === '') {
-            throw new InvalidSourceUrlException(_t(self::class . '.EMPTY_SOURCE_URL', 'Source URL is empty'));
+            return null;
         }
 
         $parts = parse_url($sourceURL);
@@ -210,6 +210,11 @@ class Embeddable extends DataExtension
     {
         try {
             $extractor = $this->getExtractor();
+            if(is_null($extractor)) {
+                // no extractor.. URL is empty
+                return false;
+            }
+
             $owner = $this->getOwner();
             // write title if current is empty
             if ($owner->EmbedTitle == '') {
@@ -254,7 +259,6 @@ class Embeddable extends DataExtension
     public function onBeforeWrite()
     {
         parent::onBeforeWrite();
-        $this->getOwner();
         $this->writeFromEmbed($this->getOwner()->ForceUpdate == '1');
     }
 


### PR DESCRIPTION
## Changes

+ When an invalid URL is detected, throw a `InvalidSourceUrlException` exception, which can be caught and return false
+ When an empty URL is provided, do not return an Extractor